### PR TITLE
Update server/accounts.js

### DIFF
--- a/server/accounts.js
+++ b/server/accounts.js
@@ -4,18 +4,19 @@ ServiceConfiguration.configurations.remove({
 });
 
 // chicago-parties.meteor.com
-ServiceConfiguration.configurations.insert({
-  service: "github",
-  clientId: "5c9b7e93a5830dd3634a",
-  secret: "1fd43cfe0e0311e726e239a7a1bec03f8c3c2c89"
-});
-
-// localhost:3000
 // ServiceConfiguration.configurations.insert({
 //   service: "github",
-//   clientId: "83f1c796a14e1f6ea61a",
-//   secret: "1c59890a41679554964713050e237ee89332731b"
+//   clientId: "5c9b7e93a5830dd3634a",
+//   secret: "1fd43cfe0e0311e726e239a7a1bec03f8c3c2c89"
 // });
+
+// localhost:3000
+//    In addition, for the provided GitHub keys below for OAuth to work, you must actually use [http://localhost:3000/] for your Meteor Test app & not a local IP [10.10.10.13].
+ServiceConfiguration.configurations.insert({
+  service: "github",
+  clientId: "83f1c796a14e1f6ea61a",
+  secret: "1c59890a41679554964713050e237ee89332731b"
+});
 
 Accounts.onCreateUser(function(options, user){
   var accessToken = user.services.github.accessToken,


### PR DESCRIPTION
I recommend you make the "localhost" the default in the GitHub repository; considering that the hosted [chicago-parties.meteor.com] version is currently defunct/offline. In addition, this information from this comment should be included in the [README.md] file.
